### PR TITLE
bug(UIKIT-847,MobxQuery): Проверка для исключения повторяющихся запросов

### DIFF
--- a/package/src/InfiniteQuery/InfiniteQuery.test.ts
+++ b/package/src/InfiniteQuery/InfiniteQuery.test.ts
@@ -130,6 +130,28 @@ describe('InfiniteQuery', () => {
     ).toBe(true);
   });
 
+  it('enabledAutoFetch:true:request:fail не происходит повторных запросов', async () => {
+    const insideExecutor = vi.fn();
+    const store = new InfiniteQuery(
+      () => {
+        insideExecutor();
+
+        return Promise.reject('foo');
+      },
+      {
+        enabledAutoFetch: true,
+        dataStorage: getDataStorage(),
+      },
+    );
+
+    expect(store.data, 'эмулируем считывание данных').toBe(undefined);
+    await when(() => !store.isLoading);
+    expect(insideExecutor, 'executor вызван в первый раз').toBeCalled();
+    expect(store.data, 'эмулируем считывание данных').toBe(undefined);
+    await when(() => !store.isLoading);
+    expect(insideExecutor, 'executor больше не вызывается').toBeCalledTimes(1);
+  });
+
   it('fetchMore: данные конкатенируются, счетчики увеличиваются, флаг достижения списка актуален', async () => {
     const insideExecutor = vi.fn();
 

--- a/package/src/InfiniteQuery/InfiniteQuery.ts
+++ b/package/src/InfiniteQuery/InfiniteQuery.ts
@@ -259,7 +259,10 @@ export class InfiniteQuery<TResult, TError = void>
    */
   public get data() {
     const shouldSync =
-      this.enabledAutoFetch && !this.isSuccess && !this.isLoading;
+      this.enabledAutoFetch &&
+      !this.isSuccess &&
+      !this.isLoading &&
+      !this.isError;
 
     if (this.isInvalid || shouldSync) {
       // т.к. при вызове апдейта, изменяются флаги, на которые подписан data,

--- a/package/src/Query/Query.test.ts
+++ b/package/src/Query/Query.test.ts
@@ -238,6 +238,28 @@ describe('Query', () => {
     ).toBe(true);
   });
 
+  it('enabledAutoFetch:true:request:fail не происходит повторных запросов', async () => {
+    const insideExecutor = vi.fn();
+    const store = new Query(
+      () => {
+        insideExecutor();
+
+        return Promise.reject('foo');
+      },
+      {
+        enabledAutoFetch: true,
+        dataStorage: getDataStorage(),
+      },
+    );
+
+    expect(store.data, 'эмулируем считывание данных').toBe(undefined);
+    await when(() => !store.isLoading);
+    expect(insideExecutor, 'executor вызван в первый раз').toBeCalled();
+    expect(store.data, 'эмулируем считывание данных').toBe(undefined);
+    await when(() => !store.isLoading);
+    expect(insideExecutor, 'executor больше не вызывается').toBeCalledTimes(1);
+  });
+
   it('data-synchronization: Данные между двумя сторами синхронизируются, если они используют одно хранилище', async () => {
     const unifiedDataStorage = getDataStorage();
 

--- a/package/src/Query/Query.ts
+++ b/package/src/Query/Query.ts
@@ -161,7 +161,10 @@ export class Query<TResult, TError = void>
    */
   public get data() {
     const shouldSync =
-      this.enabledAutoFetch && !this.isSuccess && !this.isLoading;
+      this.enabledAutoFetch &&
+      !this.isSuccess &&
+      !this.isLoading &&
+      !this.isError;
 
     if (this.isInvalid || shouldSync) {
       // т.к. при вызове апдейта, изменяются флаги, на которые подписан data,


### PR DESCRIPTION
Фикс проблемы: `Бесконечные запросы при ошибке запроса и enabledAutoFetch`

# Чеклист

- [x] Написать тесты
- [x] Описать jsdoc
- [x] Обновить документацию в README.md
