### PR TITLE
bug(UIKIT-1289): Исправлена настройка для автозапроса в createQuery

### DIFF
--- a/package/src/MobxQuery/MobxQuery.test.ts
+++ b/package/src/MobxQuery/MobxQuery.test.ts
@@ -265,4 +265,32 @@ describe('MobxQuery', () => {
     await queryBar.async();
     expect(spyExecutor).toBeCalledTimes(4);
   });
+
+  it('Автозапрос данных вызывается при enabledAutoFetch=true для всего сервиса', async () => {
+    const mobxQuery = new MobxQuery({ enabledAutoFetch: true });
+
+    const query = mobxQuery.createQuery([['foo']], () => {
+      return Promise.resolve('data');
+    });
+
+    // эмулируем обращение к data
+    JSON.stringify(query.data);
+    expect(query.isLoading).toBeTruthy();
+  });
+
+  it('Автозапрос данных не вызывается при enabledAutoFetch=false в фабричном методе и при enabledAutoFetch=true для всего сервиса', async () => {
+    const mobxQuery = new MobxQuery({ enabledAutoFetch: true });
+
+    const query = mobxQuery.createQuery(
+      [['foo']],
+      () => Promise.resolve('data'),
+      {
+        enabledAutoFetch: false,
+      },
+    );
+
+    // эмулируем обращение к data
+    JSON.stringify(query.data);
+    expect(query.isLoading).toBeFalsy();
+  });
 });

--- a/package/src/MobxQuery/MobxQuery.ts
+++ b/package/src/MobxQuery/MobxQuery.ts
@@ -196,7 +196,7 @@ export class MobxQuery<TDefaultError = void> {
           onError: (params?.onError ||
             this.defaultErrorHandler) as OnError<TError>,
           enabledAutoFetch:
-            params?.enabledAutoFetch || this.defaultEnabledAutoFetch,
+            params?.enabledAutoFetch ?? this.defaultEnabledAutoFetch,
           fetchPolicy: fetchPolicy,
           dataStorage: this.queryDataStorageFactory.getStorage(key),
         }),


### PR DESCRIPTION
Для создания корректных тестов потребовалось добавить DI для фабричных методов создания всех трех видов квери

# Чеклист

- [x] Написать тесты
- [x] Описать jsdoc
- [ ] Обновить документацию в README.md
