### PR TITLE
bug(UIKIT-1682): Исправлено дублирование данных при инвалидации

### DIFF
--- a/package/src/AuxiliaryQuery/AuxiliaryQuery.ts
+++ b/package/src/AuxiliaryQuery/AuxiliaryQuery.ts
@@ -54,7 +54,10 @@ export class AuxiliaryQuery<TResult, TError = void> {
    * Метод ответственный за создание единого промиса,
    * для устранения гонки запросов
    */
-  public getUnifiedPromise = (executor: Executor<TResult>) => {
+  public getUnifiedPromise = (
+    executor: Executor<TResult>,
+    onSuccess?: (data: TResult) => void,
+  ) => {
     // проверяем, если синглтона нет, то надо создать
     if (!Boolean(this.unifiedPromise)) {
       this.startLoading();
@@ -62,6 +65,7 @@ export class AuxiliaryQuery<TResult, TError = void> {
       this.unifiedPromise = executor()
         .then((resData: TResult) => {
           runInAction(this.submitSuccess);
+          onSuccess?.(resData);
 
           return resData;
         })

--- a/package/src/InfiniteQuery/InfiniteQuery.test.ts
+++ b/package/src/InfiniteQuery/InfiniteQuery.test.ts
@@ -16,15 +16,15 @@ describe('InfiniteQuery', () => {
       statusStorage: getStatusStorage(),
     });
 
-    it('флаг загрузки false', () => {
+    it('Флаг загрузки false', () => {
       expect(query.isLoading).toBeFalsy();
     });
 
-    it('флаг ошибки false', () => {
+    it('Флаг ошибки false', () => {
       expect(query.isError).toBeFalsy();
     });
 
-    it('флаг успеха false', () => {
+    it('Флаг успеха false', () => {
       expect(query.isSuccess).toBeFalsy();
     });
 
@@ -32,11 +32,11 @@ describe('InfiniteQuery', () => {
       expect(query.isIdle).toBeTruthy();
     });
 
-    it('data undefined', () => {
+    it('Значение data undefined', () => {
       expect(query.data).toBeUndefined();
     });
 
-    it('данные ошибки undefined', () => {
+    it('Данные ошибки undefined', () => {
       expect(query.error).toBeUndefined();
     });
   });
@@ -253,6 +253,32 @@ describe('InfiniteQuery', () => {
 
       // ожидаем, что число изменилось
       expect(secondValue !== firstValue).toBeTruthy();
+    });
+
+    it('Обращение к данным при одновременном вызове fetchMore вызывает только одно исполнение executor', async () => {
+      const executorSpy = vi.fn();
+      const query = new InfiniteQuery(
+        () => {
+          executorSpy();
+
+          return Promise.resolve(['foo']);
+        },
+        {
+          dataStorage: getDataStorage(),
+          statusStorage: getStatusStorage(),
+          enabledAutoFetch: true,
+        },
+      );
+
+      // эмулируем считывание данных
+      JSON.stringify(query.data);
+      await when(() => !query.isLoading);
+      query.invalidate();
+      // эмулируем считывание данных
+      JSON.stringify(query.data);
+      query.fetchMore();
+      await when(() => !query.isLoading);
+      expect(executorSpy).toBeCalledTimes(2);
     });
   });
 

--- a/package/src/InfiniteQuery/InfiniteQuery.ts
+++ b/package/src/InfiniteQuery/InfiniteQuery.ts
@@ -233,10 +233,10 @@ export class InfiniteQuery<
 
       // запускаем запрос с последними параметрами, и флагом необходимости инкремента
       this.auxiliary
-        .getUnifiedPromise(this.infiniteExecutor)
-        .then((resData) => {
+        .getUnifiedPromise(this.infiniteExecutor, (resData) => {
           this.submitSuccess(resData, undefined, true);
-        });
+        })
+        .catch((e) => this.defaultOnError?.(e));
     }
   };
 
@@ -262,8 +262,7 @@ export class InfiniteQuery<
     this.isEndReached = false;
 
     this.auxiliary
-      .getUnifiedPromise(this.infiniteExecutor)
-      .then((resData) => {
+      .getUnifiedPromise(this.infiniteExecutor, (resData) => {
         this.submitSuccess(resData, onSuccess);
       })
       .catch((e: TError) => {
@@ -289,18 +288,10 @@ export class InfiniteQuery<
     this.offset = 0;
     this.isEndReached = false;
 
-    return this.auxiliary
-      .getUnifiedPromise(this.infiniteExecutor)
-      .then((resData) => {
-        this.submitSuccess(resData);
-
-        return resData;
-      })
-      .catch((e) => {
-        this.auxiliary.submitError(e);
-
-        throw e;
-      });
+    return this.auxiliary.getUnifiedPromise(
+      this.infiniteExecutor,
+      this.submitSuccess,
+    );
   };
 
   /**

--- a/package/src/Mutation/Mutation.test.ts
+++ b/package/src/Mutation/Mutation.test.ts
@@ -101,6 +101,7 @@ describe('Mutation', () => {
     });
 
     sut.sync();
+    await when(() => !sut.isLoading);
     expect(spyOnError).toBeCalledWith('foo');
   });
 

--- a/package/src/Mutation/Mutation.test.ts
+++ b/package/src/Mutation/Mutation.test.ts
@@ -5,106 +5,116 @@ import { Mutation } from './Mutation';
 
 describe('Mutation', () => {
   it('Флаг простаивания true при начальном состоянии', () => {
-    const query = new Mutation(() => Promise.resolve('foo'));
+    const sut = new Mutation(() => Promise.resolve('foo'));
 
-    expect(query.isIdle).toBeTruthy();
+    expect(sut.isIdle).toBeTruthy();
   });
 
   it('Флаг простаивания false сразу после запуска запроса', () => {
-    const query = new Mutation(() => Promise.resolve('foo'));
+    const sut = new Mutation(() => Promise.resolve('foo'));
 
-    query.sync();
-    expect(query.isIdle).toBeFalsy();
+    sut.sync();
+    expect(sut.isIdle).toBeFalsy();
   });
 
-  it('Init state: флаги false, данные undefined', () => {
-    const store = new Mutation(() => Promise.resolve('foo'));
+  it('isLoading равен false при старте', () => {
+    const sut = new Mutation(() => Promise.resolve('foo'));
 
-    expect(store.isError).toBeFalsy();
-    expect(store.isLoading).toBeFalsy();
-    expect(store.error).toBeUndefined();
+    expect(sut.isLoading).toBeFalsy();
   });
 
-  it('sync: стандартная загрузка успешна', async () => {
-    const onSyncSuccess = vi.fn();
-    const store = new Mutation(() => Promise.resolve('foo'));
+  it('isError равен false при старте', () => {
+    const sut = new Mutation(() => Promise.resolve('foo'));
 
-    store.sync({ onSuccess: onSyncSuccess });
-    expect(store.isLoading).toBeTruthy();
-    await when(() => !store.isLoading);
-    expect(onSyncSuccess).toBeCalledWith('foo');
-    expect(store.isLoading).toBeFalsy();
+    expect(sut.isError).toBeFalsy();
   });
 
-  it('async: стандартная загрузка успешна', async () => {
-    const onAsyncSuccess = vi.fn();
-    const store = new Mutation(() => Promise.resolve('foo'));
+  it('error равен undefined при старте', () => {
+    const sut = new Mutation(() => Promise.resolve('foo'));
 
-    await store.async().then(onAsyncSuccess);
-    expect(onAsyncSuccess).toBeCalledWith('foo');
-    expect(store.isLoading).toBeFalsy();
+    expect(sut.error).toBeUndefined();
   });
 
-  it('sync: При вызове передаются параметры', async () => {
-    const callBack = vi.fn();
-    const store = new Mutation((params: string) => {
-      callBack(params);
+  it('Вызов sync приводит к загрузке данных', async () => {
+    const spyOnSyncSuccess = vi.fn();
+    const sut = new Mutation(() => Promise.resolve('foo'));
+
+    sut.sync({ onSuccess: spyOnSyncSuccess });
+    expect(sut.isLoading).toBeTruthy();
+    await when(() => !sut.isLoading);
+    expect(spyOnSyncSuccess).toBeCalledWith('foo');
+    expect(sut.isLoading).toBeFalsy();
+  });
+
+  it('Вызов async приводит к загрузке данных', async () => {
+    const spyOnAsyncSuccess = vi.fn();
+    const sut = new Mutation(() => Promise.resolve('foo'));
+
+    await sut.async().then(spyOnAsyncSuccess);
+    await when(() => !sut.isLoading);
+    expect(spyOnAsyncSuccess).toBeCalledWith('foo');
+    expect(sut.isLoading).toBeFalsy();
+  });
+
+  it('Вызов sync вызывает executor c переданными параметрами', async () => {
+    const executorSpy = vi.fn();
+    const sut = new Mutation((params: string) => {
+      executorSpy(params);
 
       return Promise.resolve('foo');
     });
 
-    store.sync({ params: 'bar' });
-    await when(() => !store.isLoading);
-    expect(callBack).toBeCalledWith('bar');
+    sut.sync({ params: 'bar' });
+    await when(() => !sut.isLoading);
+    expect(executorSpy).toBeCalledWith('bar');
   });
 
-  it('async: При вызове передаются параметры', async () => {
-    const callBack = vi.fn();
-    const store = new Mutation((params: string) => {
-      callBack(params);
+  it('Вызов async вызывает executor с переданными параметрами', async () => {
+    const spyExecutor = vi.fn();
+    const sut = new Mutation((params: string) => {
+      spyExecutor(params);
 
       return Promise.resolve('foo');
     });
 
-    await store.async('bar');
-    expect(callBack).toBeCalledWith('bar');
+    await sut.async('bar');
+    expect(spyExecutor).toBeCalledWith('bar');
   });
 
-  it('sync: при провальном запросе вызывается onError', async () => {
-    const store = new Mutation(() => Promise.reject('foo'));
+  it('onError вызывается c данными ошибки при провальном запросе', async () => {
+    const spyOnError = vi.fn();
+    const sut = new Mutation(() => Promise.reject('foo'));
 
-    store.sync({
-      onError: (e) => {
-        expect(store.isLoading).toBeFalsy();
-        expect(store.isError).toBeTruthy();
-        expect(e).toBe('foo');
-      },
+    sut.sync({
+      onError: spyOnError,
     });
+
+    await when(() => !sut.isLoading);
+    expect(spyOnError).toBeCalledWith('foo');
   });
 
-  it('sync: при провальном запросе вызывается стандартный onError', async () => {
-    const store = new Mutation(() => Promise.reject('foo'), {
-      onError: (e) => {
-        expect(store.isLoading).toBeFalsy();
-        expect(store.isError).toBeTruthy();
-        expect(e).toBe('foo');
-      },
+  it('Стандартный onError вызывается с данными ошибки при провальном запросе', async () => {
+    const spyOnError = vi.fn();
+
+    const sut = new Mutation(() => Promise.reject('foo'), {
+      onError: spyOnError,
     });
 
-    store.sync();
+    sut.sync();
+    expect(spyOnError).toBeCalledWith('foo');
   });
 
-  it('async: При провальном запросе вызывается не вызывается стандартный onError', async () => {
-    const onDefaultError = vi.fn();
-    const onAsyncError = vi.fn();
-    const store = new Mutation(() => Promise.reject('foo'), {
-      onError: onDefaultError,
+  it('Стандартный onError не вызывается при использовании дополнительного', async () => {
+    const spyOnDefaultError = vi.fn();
+    const spyOnAsyncError = vi.fn();
+    const sut = new Mutation(() => Promise.reject('foo'), {
+      onError: spyOnDefaultError,
     });
 
-    await store.async().catch(onAsyncError);
-    expect(store.isError).toBeTruthy();
-    expect(onAsyncError).toBeCalledWith('foo');
-    expect(onDefaultError).not.toBeCalled();
+    await sut.async().catch(spyOnAsyncError);
+    await when(() => !sut.isLoading);
+    expect(spyOnAsyncError).toBeCalledWith('foo');
+    expect(spyOnDefaultError).not.toBeCalled();
   });
 
   it('Модель фоновых статусов background равен null', () => {

--- a/package/src/Mutation/Mutation.ts
+++ b/package/src/Mutation/Mutation.ts
@@ -55,10 +55,12 @@ export class Mutation<TResult, TError = void, TExecutorParams = void>
     const { onSuccess, onError, params } = options || {};
 
     this.auxiliary
-      .getUnifiedPromise(() => this.executor(params as TExecutorParams))
-      .then((resData) => {
-        onSuccess?.(resData);
-      })
+      .getUnifiedPromise(
+        () => this.executor(params as TExecutorParams),
+        (resData) => {
+          onSuccess?.(resData);
+        },
+      )
       .catch((e: TError) => {
         if (onError) {
           onError(e);

--- a/package/src/Query/Query.ts
+++ b/package/src/Query/Query.ts
@@ -171,8 +171,7 @@ export class Query<
     const { onSuccess, onError } = options || {};
 
     this.auxiliary
-      .getUnifiedPromise(this.executor)
-      .then((res) => {
+      .getUnifiedPromise(this.executor, (res) => {
         this.submitSuccess(res);
         onSuccess?.(res);
       })
@@ -194,9 +193,7 @@ export class Query<
       return Promise.resolve(this.storage.data as TResult);
     }
 
-    return this.auxiliary
-      .getUnifiedPromise(this.executor)
-      .then(this.submitSuccess);
+    return this.auxiliary.getUnifiedPromise(this.executor, this.submitSuccess);
   };
 
   /**


### PR DESCRIPTION
Проблема заключалась в том, что finally под капотом работает как обычный then. т.е. он по очередности исполнения оказывается не последним, как ожидалось, а просто следующим. Из-за этого, обнуление unifiedPromise происходило слишком рано, и это в крайниих кейсах приводило к появлению неожиданных новых запросов.

Решение - перенос обработчиков успешности внутрь unifiedPromise, отчего finally по сути будет исполняться после onSuccess обработчиков, как и ожидалось.

# Чеклист

- [x] Написать тесты
- [ ] Описать jsdoc
- [ ] Обновить документацию в README.md
